### PR TITLE
Allow missing summary and only include optional method sections if present

### DIFF
--- a/sphinxcontrib/swaggerdoc/swaggerv2_doc.py
+++ b/sphinxcontrib/swaggerdoc/swaggerv2_doc.py
@@ -112,17 +112,24 @@ class SwaggerV2DocDirective(Directive):
         swagger_node += nodes.title(path, method_type.upper() + ' ' + path)
 
         paragraph = nodes.paragraph()
-        paragraph += nodes.Text(method['summary'])
+        paragraph += nodes.Text(method.get('summary', ''))
 
         bullet_list = nodes.bullet_list()
-        bullet_list += self.create_item('Description: ', method.get('description', ''))
-        bullet_list += self.create_item('Consumes: ', self.expand_values(method.get('consumes', '')))
-        bullet_list += self.create_item('Produces: ', self.expand_values(method.get('produces', '')))
+
+        method_sections = {'Description': 'description', 'Consumes': 'consumes', 'Produces': 'produces'}
+        for title in method_sections:
+            value_name = method_sections[title]
+            value = method.get(value_name)
+            if value is not None:
+                bullet_list += self.create_item(title + ': \n', value)
+
         paragraph += bullet_list
 
         swagger_node += paragraph
 
-        swagger_node += self.make_parameters(method['parameters'])
+        parameters = method.get('parameters')
+        if parameters is not None:
+            swagger_node += self.make_parameters(parameters)
 
         return [swagger_node]
 


### PR DESCRIPTION
Doesn't include output if a section such as 'consumes' contains nothing. Closes #11
Allows for a missing summary. Closes #10