### PR TITLE
Fixed Unicode response info rendering in Python 2.

### DIFF
--- a/sphinxcontrib/swaggerdoc/swaggerv2_doc.py
+++ b/sphinxcontrib/swaggerdoc/swaggerv2_doc.py
@@ -106,8 +106,8 @@ class SwaggerV2DocDirective(Directive):
         head = ['Name', 'Description', 'Type']
         for response_name, response in responses.items():
             paragraph = nodes.paragraph()
-            paragraph += nodes.emphasis('', '{} - {}'.format(response_name,
-                                                             response.get('description', '')))
+            paragraph += nodes.emphasis('', '%s - %s' % (response_name,
+                                                         response.get('description', '')))
             entries.append(paragraph)
 
             body = []


### PR DESCRIPTION
This patch fixes the following:
```
Traceback (most recent call last):
  File "/home/phil/build/apidocs/env/local/lib/python2.7/site-packages/sphinxcontrib/swaggerdoc/swaggerv2_doc.py", line 238, in run
    section += self.make_method(path, method_type, method)
  File "/home/phil/build/apidocs/env/local/lib/python2.7/site-packages/sphinxcontrib/swaggerdoc/swaggerv2_doc.py", line 180, in make_method
    swagger_node += self.make_responses(responses)
  File "/home/phil/build/apidocs/env/local/lib/python2.7/site-packages/sphinxcontrib/swaggerdoc/swaggerv2_doc.py", line 110, in make_responses
    response.get('description', '')))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-4: ordinal not in range(128)
```
Looking at the rest of the code, I concluded that the original %-style formatting is preferred, and it is both Python 2 and Python 3 compatible and Unicode-agnostic as well.