### PR TITLE
Fixed parsing valid OpenAPI 2.0 with undeclared tags.

### DIFF
--- a/sphinxcontrib/swaggerdoc/swaggerv2_doc.py
+++ b/sphinxcontrib/swaggerdoc/swaggerv2_doc.py
@@ -197,7 +197,7 @@ class SwaggerV2DocDirective(Directive):
                     groups[SwaggerV2DocDirective.DEFAULT_GROUP].append((path, method_type, method))
                 else:
                     for tag in method['tags']:
-                        groups[tag].append((path, method_type, method))
+                        groups.setdefault(tag, []).append((path, method_type, method))
 
         return groups
 


### PR DESCRIPTION
This patch fixes the following:
```
Traceback (most recent call last):
  File "/home/phil/build/apidocs/env/local/lib/python2.7/site-packages/sphinxcontrib/swaggerdoc/swaggerv2_doc.py", line 228, in run
    groups = self.group_tags(api_desc)
  File "/home/phil/build/apidocs/env/local/lib/python2.7/site-packages/sphinxcontrib/swaggerdoc/swaggerv2_doc.py", line 200, in group_tags
    groups[tag].append((path, method_type, method))
KeyError: '/some_api_path/'
```
which happens when the root `tags` element does not contain some of the tags mentioned within Operation objects. However, the document passes validation, and the OpenAPI 2.0 Specification says:
> Not all tags that are used by the Operation Object must be declared. The tags that are not declared may be organized randomly or based on the tools' logic.