### PR TITLE
Prevent a KeyError when tags isn't present

### DIFF
--- a/sphinxcontrib/swaggerdoc/swaggerv2_doc.py
+++ b/sphinxcontrib/swaggerdoc/swaggerv2_doc.py
@@ -196,7 +196,7 @@ class SwaggerV2DocDirective(Directive):
                 if SwaggerV2DocDirective.DEFAULT_GROUP in groups:
                     groups[SwaggerV2DocDirective.DEFAULT_GROUP].append((path, method_type, method))
                 else:
-                    for tag in method['tags']:
+                    for tag in method.get('tags', []):
                         groups.setdefault(tag, []).append((path, method_type, method))
 
         return groups


### PR DESCRIPTION
I was running into this with a spec that doesn't define tags for each path item. I don't believe tags are necessary as it doesn't cause any validation issues.