### PR TITLE
Add optional YAML support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,15 @@ generates the documentation for the methods contained in tags **pet** and
        pet
        store
 
+You can also use use YAML defined swagger specs. But you will need
+to install this distribution with the ``yaml`` requirements extra
+(i.e. ``sphinx-swaggerdoc[yaml]``); or manually install PyYAML.
+Note, YAML is used when the file exention is ``.yaml`` or ``.yml``.
+
+.. code:: restructuredtext
+
+    .. swaggerv2doc:: file:///PATH/swagger.yaml
+
 Note
 ====
 

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,8 @@ setup(
         'Topic :: Utilities'
     ],
     packages=find_packages(),
-    install_requires=['sphinx', 'requests', 'requests-file', 'future']
+    install_requires=['sphinx', 'requests', 'requests-file', 'future'],
+    extras_require = {
+        'yaml': ['PyYAML'],
+    },
 )

--- a/sphinxcontrib/swaggerdoc/swaggerv2_doc.py
+++ b/sphinxcontrib/swaggerdoc/swaggerv2_doc.py
@@ -11,6 +11,7 @@ from six.moves.urllib import parse as urlparse   # Retain Py2 compatibility for 
 import requests
 from requests_file import FileAdapter
 import json
+import yaml
 
 class swaggerv2doc(nodes.Admonition, nodes.Element):
     pass
@@ -37,6 +38,9 @@ class SwaggerV2DocDirective(Directive):
 
             with open(absfn) as fd:
                 content = fd.read()
+
+            if url[-4:] in ['.yml', 'yaml']:
+                return yaml.load(content)
 
             return json.loads(content)
         else:

--- a/sphinxcontrib/swaggerdoc/swaggerv2_doc.py
+++ b/sphinxcontrib/swaggerdoc/swaggerv2_doc.py
@@ -5,13 +5,18 @@ import traceback
 from docutils.parsers.rst import Directive
 from past.builtins import basestring
 
+from sphinx.errors import SphinxError
 from sphinx.locale import _
 
 from six.moves.urllib import parse as urlparse   # Retain Py2 compatibility for urlparse
 import requests
 from requests_file import FileAdapter
 import json
-import yaml
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
 
 class swaggerv2doc(nodes.Admonition, nodes.Element):
     pass
@@ -40,6 +45,13 @@ class SwaggerV2DocDirective(Directive):
                 content = fd.read()
 
             if url[-4:] in ['.yml', 'yaml']:
+                if yaml is None:
+                    raise SphinxError(
+                        'YAML support is optional. If you choose to use it '
+                        'please install this distribution with the `yaml` '
+                        'requirements extra '
+                        '(i.e. `sphinx-swaggerdoc[yaml]`). '
+                        'Or manually install PyYAML.')
                 return yaml.load(content)
 
             return json.loads(content)


### PR DESCRIPTION
This adds the option to read the swagger spec from a YAML formatted document.  I could use this feature since my spec is written in yaml and is only rendered to json by the web server.